### PR TITLE
feat: Add XmiLine3d equality methods with referential, directional, and coincident comparison

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,5 @@
+{
+  "disabledMcpjsonServers": [
+    "github"
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ The library is organized into the following namespaces:
 ### Core Types
 
 **Base Classes** (`XmiSchema.Entities.Bases`):
-- `XmiBaseEntity`: Root for all entities. Provides `ID`, `ifcGuid`, `NativeId`, `Description`, and `EntityType` (polymorphic discriminator for JSON serialization).
+- `XmiBaseEntity`: Root for all entities. Provides `ID`, `ifcGuid`, `NativeId`, `Description`, and `EntityName` (polymorphic discriminator for JSON serialization).
 - `XmiBaseGeometry`: Extends `XmiBaseEntity` for geometric primitives (points, lines, arcs).
 - `XmiBaseRelationship`: Base for all graph edges, holding source/target entity references and UML stereotypes.
 - `XmiBasePhysicalEntity`: Intermediate base for physical elements (beams, columns, slabs, walls).
@@ -135,12 +135,12 @@ Maintain consistent parameter order across all new entities:
 [id, name, ifcGuid, nativeId, description, ...domain-specific-args]
 ```
 
-### EntityType Discriminator
+### EntityName Discriminator
 All entity constructors must pass the entity type name to the base constructor:
 ```csharp
 public XmiBeam(...) : base("XmiBeam", id, name, ifcGuid, nativeId, description, domain)
 ```
-This ensures JSON serialization emits the correct `"EntityType"` discriminator for polymorphic deserialization.
+This ensures JSON serialization emits the correct `"EntityName"` discriminator for polymorphic deserialization.
 
 ### Relationship Constructors
 Provide two constructors:
@@ -213,7 +213,7 @@ tests/
 
 ## Important Notes
 
-- **JSON Serialization**: Uses Newtonsoft.Json. Polymorphic entities rely on the `EntityType` discriminator.
+- **JSON Serialization**: Uses Newtonsoft.Json. Polymorphic entities rely on the `EntityName` discriminator.
 - **Point Deduplication**: Always create points via `XmiModel.CreatePoint3D()` to avoid duplicate coordinates in the graph.
 - **Shape Parameters**: Reference `Enums/XmiShapeEnumParameters.cs` for the canonical list of parameter keys per shape type.
 - **Target Framework**: `net8.0` for both library and tests.

--- a/Entities/Bases/README.md
+++ b/Entities/Bases/README.md
@@ -2,9 +2,9 @@
 
 The base layer defines traits shared by every entity, geometry, and relationship in the XmiSchema package.
 
-- `XmiBaseEntity`: Provides identifiers (`ID`, `ifcGuid`, `NativeId`), descriptive text, and an `EntityType` string that controls serialization. All entities must inherit from this class and invoke its constructor with a sensible fallback name.
-- `XmiBaseGeometry`: Extends `XmiBaseEntity` for spatial primitives. When creating new geometries, call the base constructor with the entity type name so serializers emit the correct discriminator.
+- `XmiBaseEntity`: Provides identifiers (`ID`, `ifcGuid`, `NativeId`), descriptive text, an `EntityName` discriminator, and a `Domain` classification. All entities must inherit from this class and invoke its constructor with a sensible fallback name.
+- `XmiBaseGeometry`: Extends `XmiBaseEntity` for spatial primitives. When creating new geometries, call the base constructor with the entity name so serializers emit the correct discriminator.
 - `XmiBaseRelationship`: Stores the source/target nodes, UML stereotype, and descriptive metadata for graph edges. Relationship classes typically expose two constructors: a fully described one, and a shorthand that auto-generates the ID.
 - `EnumValueAttribute` (`XmiBaseEnum.cs`): Decorates enum members with the serialized string consumed by authoring tools. Use it together with `ExtensionEnumHelper.FromEnumValue` to parse raw values safely.
 
-All new domain classes should build on these abstractions to maintain consistency across models and to guarantee compatibility with the JSON serializer and downstream connectors.*** End Patch
+All new domain classes should build on these abstractions to maintain consistency across models and to guarantee compatibility with the JSON serializer and downstream connectors.

--- a/Entities/Bases/XmiBaseEntity.cs
+++ b/Entities/Bases/XmiBaseEntity.cs
@@ -25,11 +25,11 @@ namespace XmiSchema.Entities.Bases
         public string Description { get; set; }
 
         [JsonProperty(Order = 5)]
-        public string EntityType { get; set; }
+        public string EntityName { get; set; }
 
         [JsonProperty(Order = 6)]
         [JsonConverter(typeof(StringEnumConverter))]
-        public XmiBaseEntityDomainEnum Type { get; set; }
+        public XmiBaseEntityDomainEnum Domain { get; set; }
 
         // 带参数构造函数
         /// <summary>
@@ -40,16 +40,16 @@ namespace XmiSchema.Entities.Bases
         /// <param name="ifcGuid">IFC GUID reference when available.</param>
         /// <param name="nativeId">Identifier from the native source system.</param>
         /// <param name="description">Describes the entity purpose.</param>
-        /// <param name="entityType">Type hint emitted in payloads.</param>
-        /// <param name="type">Domain classification for the entity.</param>
+        /// <param name="entityName">Domain hint emitted in payloads.</param>
+        /// <param name="domain">Domain classification for the entity.</param>
         public XmiBaseEntity(
             string id,
             string name,
             string ifcGuid,
             string nativeId,
             string description,
-            string entityType,
-            XmiBaseEntityDomainEnum type
+            string entityName,
+            XmiBaseEntityDomainEnum domain
         )
         {
             Id = id;
@@ -58,8 +58,8 @@ namespace XmiSchema.Entities.Bases
             IfcGuid = ifcGuid;
             NativeId = nativeId;
             Description = description;
-            EntityType = string.IsNullOrEmpty(entityType) ? nameof(XmiBaseEntity) : entityType;
-            Type = type;
+            EntityName = string.IsNullOrEmpty(entityName) ? nameof(XmiBaseEntity) : entityName;
+            Domain = domain;
         }
     }
 }

--- a/Entities/Bases/XmiBaseGeometry.cs
+++ b/Entities/Bases/XmiBaseGeometry.cs
@@ -15,16 +15,16 @@ public abstract class XmiBaseGeometry : XmiBaseEntity
     /// <param name="ifcGuid">IFC GUID reference.</param>
     /// <param name="nativeId">Native identifier from the authoring tool.</param>
     /// <param name="description">Describes the geometry.</param>
-    /// <param name="entityType">Optional entity type override.</param>
+    /// <param name="entityName">Optional entity name override.</param>
     public XmiBaseGeometry(
         string id,
         string name,
         string ifcGuid,
         string nativeId,
         string description,
-        string? entityType = null)
+        string? entityName = null)
         : base(id, name, ifcGuid, nativeId, description,
-               string.IsNullOrEmpty(entityType) ? nameof(XmiBaseGeometry) : entityType,
+               string.IsNullOrEmpty(entityName) ? nameof(XmiBaseGeometry) : entityName,
                XmiBaseEntityDomainEnum.Geometry)
     {
     }

--- a/Entities/Bases/XmiBasePhysicalEntity.cs
+++ b/Entities/Bases/XmiBasePhysicalEntity.cs
@@ -15,15 +15,15 @@ namespace XmiSchema.Entities.Bases
         /// <param name="ifcGuid">IFC GUID reference when available.</param>
         /// <param name="nativeId">Identifier from the native source system.</param>
         /// <param name="description">Describes the entity purpose.</param>
-        /// <param name="entityType">Type hint emitted in payloads.</param>
+        /// <param name="entityName">Entity name emitted in payloads.</param>
         protected XmiBasePhysicalEntity(
             string id,
             string name,
             string ifcGuid,
             string nativeId,
             string description,
-            string entityType
-        ) : base(id, name, ifcGuid, nativeId, description, entityType, XmiBaseEntityDomainEnum.Physical)
+            string entityName
+        ) : base(id, name, ifcGuid, nativeId, description, entityName, XmiBaseEntityDomainEnum.Physical)
         {
         }
     }

--- a/Entities/Bases/XmiBaseRelationship.cs
+++ b/Entities/Bases/XmiBaseRelationship.cs
@@ -13,7 +13,7 @@ public class XmiBaseRelationship
     public XmiBaseEntity Target { get; set; }
     public string Name { get; set; }
     public string Description { get; set; }
-    public string EntityType { get; set; }
+    public string EntityName { get; set; }
     /// <summary>
     /// Optional metadata bag for downstream consumers (e.g., nodeType=Begin/End).
     /// </summary>
@@ -26,7 +26,7 @@ public class XmiBaseRelationship
     /// <param name="target">Entity at the destination of the edge.</param>
     /// <param name="name">Readable label.</param>
     /// <param name="description">Notes for downstream consumers.</param>
-    /// <param name="entityType">Type name recorded in the payload.</param>
+    /// <param name="entityName">Entity name recorded in the payload.</param>
     /// <param name="properties">Optional metadata to attach to the relationship.</param>
     public XmiBaseRelationship(
         string id,
@@ -34,7 +34,7 @@ public class XmiBaseRelationship
         XmiBaseEntity target,
         string name,
         string description,
-        string entityType,
+        string entityName,
         Dictionary<string, string>? properties = null
     )
     {
@@ -43,7 +43,7 @@ public class XmiBaseRelationship
         Target = target;
         Name = string.IsNullOrEmpty(name) ? "Unnamed"  : name;
         Description = string.IsNullOrEmpty(description) ? "" : description;
-        EntityType = string.IsNullOrEmpty(entityType) ? nameof(XmiBaseRelationship) : entityType;
+        EntityName = string.IsNullOrEmpty(entityName) ? nameof(XmiBaseRelationship) : entityName;
         Properties = properties ?? new Dictionary<string, string>();
     }
     /// <summary>
@@ -51,10 +51,10 @@ public class XmiBaseRelationship
     /// </summary>
     /// <param name="source">Entity at the origin of the edge.</param>
     /// <param name="target">Entity at the destination of the edge.</param>
-    /// <param name="entityType">Type name recorded in the payload.</param>
+    /// <param name="entityName">Entity name recorded in the payload.</param>
     /// <param name="properties">Optional metadata to attach to the relationship.</param>
-    public XmiBaseRelationship(XmiBaseEntity source, XmiBaseEntity target, string entityType, Dictionary<string, string>? properties = null)
-            : this(Guid.NewGuid().ToString(), source, target, entityType, "", entityType, properties)
+    public XmiBaseRelationship(XmiBaseEntity source, XmiBaseEntity target, string entityName, Dictionary<string, string>? properties = null)
+            : this(Guid.NewGuid().ToString(), source, target, entityName, "", entityName, properties)
     {
     }
 }

--- a/Entities/Bases/XmiBaseStructuralAnalyticalEntity.cs
+++ b/Entities/Bases/XmiBaseStructuralAnalyticalEntity.cs
@@ -15,15 +15,15 @@ namespace XmiSchema.Entities.Bases
         /// <param name="ifcGuid">IFC GUID reference when available.</param>
         /// <param name="nativeId">Identifier from the native source system.</param>
         /// <param name="description">Describes the entity purpose.</param>
-        /// <param name="entityType">Type hint emitted in payloads.</param>
+        /// <param name="entityName">Entity name emitted in payloads.</param>
         protected XmiBaseStructuralAnalyticalEntity(
             string id,
             string name,
             string ifcGuid,
             string nativeId,
             string description,
-            string entityType
-        ) : base(id, name, ifcGuid, nativeId, description, entityType, XmiBaseEntityDomainEnum.StructuralAnalytical)
+            string entityName
+        ) : base(id, name, ifcGuid, nativeId, description, entityName, XmiBaseEntityDomainEnum.StructuralAnalytical)
         {
         }
     }

--- a/Entities/Commons/XmiSegment.cs
+++ b/Entities/Commons/XmiSegment.cs
@@ -11,10 +11,7 @@ public class XmiSegment : XmiBaseEntity
 
     // public XmiBaseGeometry Geometry { get; set; }   // Surface member the support is assigned to
     public float Position { get; set; }
-    // public XmiStructuralPointConnection BeginNode { get; set; }
-    // public XmiStructuralPointConnection EndNode { get; set; }
     public XmiSegmentTypeEnum SegmentType { get; set; }
-
 
     // 带参数构造函数（包含父类属性 + 子类属性）
     /// <summary>
@@ -40,11 +37,7 @@ public class XmiSegment : XmiBaseEntity
         XmiSegmentTypeEnum segmentType
     ) : base(id, name, ifcGuid, nativeId, description, nameof(XmiSegment), XmiBaseEntityDomainEnum.Shared)
     {
-        // Geometry = geometry;
         Position = position;
-        // BeginNode = beginNode;
-
-        // EndNode = endNode;
         SegmentType = segmentType;
     }
 }

--- a/Entities/Geometries/XmiArc3d.cs
+++ b/Entities/Geometries/XmiArc3d.cs
@@ -40,6 +40,6 @@ public class XmiArc3d : XmiBaseGeometry
         EndPoint = endPoint;
         CenterPoint = centerPoint;
         Radius = radius;
-        EntityType = nameof(XmiArc3d);
+        EntityName = nameof(XmiArc3d);
     }
 }

--- a/Entities/Geometries/XmiLine3d.cs
+++ b/Entities/Geometries/XmiLine3d.cs
@@ -5,7 +5,7 @@ namespace XmiSchema.Entities.Geometries;
 /// <summary>
 /// Defines a straight 3D line segment between two <see cref="XmiPoint3d"/> nodes.
 /// </summary>
-public class XmiLine3d : XmiBaseGeometry
+public class XmiLine3d : XmiBaseGeometry, IEquatable<XmiLine3d>
 {
     public XmiPoint3d StartPoint { get; set; }
     public XmiPoint3d EndPoint { get; set; }
@@ -33,5 +33,62 @@ public class XmiLine3d : XmiBaseGeometry
         StartPoint = startPoint;
         EndPoint = endPoint;
         EntityName = nameof(XmiLine3d);
+    }
+
+    /// <summary>
+    /// Referential equality: checks if both lines reference
+    /// the exact same <see cref="XmiPoint3d"/> instances.
+    /// Use for graph connectivity checks.
+    /// </summary>
+    /// <param name="other">The line to compare against.</param>
+    /// <returns>True if both StartPoint and EndPoint are the same references.</returns>
+    public bool Equals(XmiLine3d? other)
+    {
+        if (other == null) return false;
+        return ReferenceEquals(StartPoint, other.StartPoint) &&
+               ReferenceEquals(EndPoint, other.EndPoint);
+    }
+
+    /// <summary>
+    /// Directional equality: checks if two lines have the same
+    /// coordinates AND the same vector direction.
+    /// Start→End must match Start→End (not reversed).
+    /// Use when direction/vector matters (e.g., load direction).
+    /// </summary>
+    /// <param name="other">The line to compare against.</param>
+    /// <returns>True if coordinates match within tolerance and direction is the same.</returns>
+    public bool IsDirectionallyEqual(XmiLine3d? other)
+    {
+        if (other == null) return false;
+        return StartPoint.Equals(other.StartPoint) &&
+               EndPoint.Equals(other.EndPoint);
+    }
+
+    /// <summary>
+    /// Coincident equality: checks if two lines occupy the same
+    /// space, regardless of direction.
+    /// A→B is considered coincident with B→A.
+    /// Use for geometry deduplication where direction doesn't matter.
+    /// </summary>
+    /// <param name="other">The line to compare against.</param>
+    /// <returns>True if the lines occupy the same space, regardless of direction.</returns>
+    public bool IsCoincident(XmiLine3d? other)
+    {
+        if (other == null) return false;
+
+        bool sameDirection = StartPoint.Equals(other.StartPoint) &&
+                             EndPoint.Equals(other.EndPoint);
+
+        bool oppositeDirection = StartPoint.Equals(other.EndPoint) &&
+                                 EndPoint.Equals(other.StartPoint);
+
+        return sameDirection || oppositeDirection;
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(StartPoint?.GetHashCode() ?? 0,
+                                EndPoint?.GetHashCode() ?? 0);
     }
 }

--- a/Entities/Geometries/XmiLine3d.cs
+++ b/Entities/Geometries/XmiLine3d.cs
@@ -32,6 +32,6 @@ public class XmiLine3d : XmiBaseGeometry
     {
         StartPoint = startPoint;
         EndPoint = endPoint;
-        EntityType = nameof(XmiLine3d);
+        EntityName = nameof(XmiLine3d);
     }
 }

--- a/Entities/Geometries/XmiPoint3d.cs
+++ b/Entities/Geometries/XmiPoint3d.cs
@@ -44,7 +44,7 @@ public class XmiPoint3d : XmiBaseGeometry, IEquatable<XmiPoint3d>
         X = x;
         Y = y;
         Z = z;
-        EntityType = nameof(XmiPoint3d);
+        EntityName = nameof(XmiPoint3d);
     }
 
     public bool Equals(XmiPoint3d? other)

--- a/Entities/Relationships/XmiHasArc3d.cs
+++ b/Entities/Relationships/XmiHasArc3d.cs
@@ -1,4 +1,5 @@
 using XmiSchema.Entities.Bases;
+using XmiSchema.Entities.Geometries;
 
 namespace XmiSchema.Entities.Relationships;
 
@@ -13,7 +14,7 @@ public class XmiHasArc3d : XmiBaseRelationship
     public XmiHasArc3d(
         string id,
         XmiBaseEntity source,
-        XmiBaseEntity target,
+        XmiArc3d target,
         string name,
         string description,
         string entityName
@@ -26,7 +27,7 @@ public class XmiHasArc3d : XmiBaseRelationship
     /// </summary>
     public XmiHasArc3d(
         XmiBaseEntity source,
-        XmiBaseEntity target
+        XmiArc3d target
     ) : base(source, target, nameof(XmiHasArc3d))
     {
     }

--- a/Entities/Relationships/XmiHasCrossSection.cs
+++ b/Entities/Relationships/XmiHasCrossSection.cs
@@ -1,4 +1,5 @@
 using XmiSchema.Entities.Bases;
+using XmiSchema.Entities.Commons;
 
 namespace XmiSchema.Entities.Relationships;
 
@@ -19,7 +20,7 @@ public class XmiHasCrossSection : XmiBaseRelationship
     public XmiHasCrossSection(
         string id,
         XmiBaseEntity source,
-        XmiBaseEntity target,
+        XmiCrossSection target,
         string name,
         string description,
         string entityName
@@ -34,7 +35,7 @@ public class XmiHasCrossSection : XmiBaseRelationship
     /// <param name="target">Cross-section entity.</param>
     public XmiHasCrossSection(
         XmiBaseEntity source,
-        XmiBaseEntity target
+        XmiCrossSection target
     ) : base(source, target, nameof(XmiHasCrossSection))
     {
     }

--- a/Entities/Relationships/XmiHasGeometry.cs
+++ b/Entities/Relationships/XmiHasGeometry.cs
@@ -15,7 +15,7 @@ public class XmiHasGeometry : XmiBaseRelationship
     /// <param name="target">Geometry entity.</param>
     /// <param name="name">Descriptive label.</param>
     /// <param name="description">Optional notes.</param>
-    /// <param name="entityName">Type name emitted in serialized payloads.</param>
+    /// <param name="entityName">Domain name emitted in serialized payloads.</param>
     public XmiHasGeometry(
         string id,
         XmiBaseEntity source,

--- a/Entities/Relationships/XmiHasLine3d.cs
+++ b/Entities/Relationships/XmiHasLine3d.cs
@@ -1,4 +1,5 @@
 using XmiSchema.Entities.Bases;
+using XmiSchema.Entities.Geometries;
 
 namespace XmiSchema.Entities.Relationships;
 
@@ -19,7 +20,7 @@ public class XmiHasLine3d : XmiBaseRelationship
     public XmiHasLine3d(
         string id,
         XmiBaseEntity source,
-        XmiBaseEntity target,
+        XmiLine3d target,
         string name,
         string description,
         string entityName
@@ -34,8 +35,53 @@ public class XmiHasLine3d : XmiBaseRelationship
     /// <param name="target">Related entity.</param>
     public XmiHasLine3d(
         XmiBaseEntity source,
-        XmiBaseEntity target
+        XmiLine3d target
     ) : base(source, target, nameof(XmiHasLine3d))
     {
+    }
+
+    /// <summary>
+    /// Gets the target as a strongly-typed <see cref="XmiLine3d"/>.
+    /// </summary>
+    public XmiLine3d TargetLine3d => (XmiLine3d)Target;
+
+    /// <summary>
+    /// Checks if this relationship's target references the exact same
+    /// <see cref="XmiPoint3d"/> instances as the other relationship's target.
+    /// Use for graph connectivity checks.
+    /// </summary>
+    /// <param name="other">The relationship to compare against.</param>
+    /// <returns>True if both targets share the same point references.</returns>
+    public bool HasSameTarget(XmiHasLine3d? other)
+    {
+        if (other == null) return false;
+        return TargetLine3d.Equals(other.TargetLine3d);
+    }
+
+    /// <summary>
+    /// Checks if this relationship's target has the same coordinates
+    /// AND the same vector direction as the other relationship's target.
+    /// Use when direction/vector matters (e.g., load direction).
+    /// </summary>
+    /// <param name="other">The relationship to compare against.</param>
+    /// <returns>True if targets have same coordinates and direction.</returns>
+    public bool HasDirectionallyEqualTarget(XmiHasLine3d? other)
+    {
+        if (other == null) return false;
+        return TargetLine3d.IsDirectionallyEqual(other.TargetLine3d);
+    }
+
+    /// <summary>
+    /// Checks if this relationship's target occupies the same space
+    /// as the other relationship's target, regardless of direction.
+    /// A→B is considered coincident with B→A.
+    /// Use for geometry deduplication.
+    /// </summary>
+    /// <param name="other">The relationship to compare against.</param>
+    /// <returns>True if targets occupy the same space.</returns>
+    public bool HasCoincidentTarget(XmiHasLine3d? other)
+    {
+        if (other == null) return false;
+        return TargetLine3d.IsCoincident(other.TargetLine3d);
     }
 }

--- a/Entities/Relationships/XmiHasMaterial.cs
+++ b/Entities/Relationships/XmiHasMaterial.cs
@@ -1,4 +1,5 @@
 using XmiSchema.Entities.Bases;
+using XmiSchema.Entities.Commons;
 
 namespace XmiSchema.Entities.Relationships;
 
@@ -19,7 +20,7 @@ public class XmiHasMaterial : XmiBaseRelationship
     public XmiHasMaterial(
         string id,
         XmiBaseEntity source,
-        XmiBaseEntity target,
+        XmiMaterial target,
         string name,
         string description,
         string entityName
@@ -34,7 +35,7 @@ public class XmiHasMaterial : XmiBaseRelationship
     /// <param name="target">Material entity.</param>
     public XmiHasMaterial(
         XmiBaseEntity source,
-        XmiBaseEntity target
+        XmiMaterial target
     ) : base(source, target, nameof(XmiHasMaterial))
     {
     }

--- a/Entities/Relationships/XmiHasPoint3d.cs
+++ b/Entities/Relationships/XmiHasPoint3d.cs
@@ -1,4 +1,5 @@
 using XmiSchema.Entities.Bases;
+using XmiSchema.Entities.Geometries;
 using XmiSchema.Enums;
 
 namespace XmiSchema.Entities.Relationships;
@@ -26,7 +27,7 @@ public class XmiHasPoint3d : XmiBaseRelationship
     public XmiHasPoint3d(
         string id,
         XmiBaseEntity source,
-        XmiBaseEntity target,
+        XmiPoint3d target,
         string name,
         string description,
         string entityName,
@@ -44,7 +45,7 @@ public class XmiHasPoint3d : XmiBaseRelationship
     /// <param name="pointType">Optional role of the point (Start, End, Center).</param>
     public XmiHasPoint3d(
         XmiBaseEntity source,
-        XmiBaseEntity target,
+        XmiPoint3d target,
         XmiPoint3dTypeEnum? pointType = null
     ) : base(source, target, nameof(XmiHasPoint3d))
     {

--- a/Entities/Relationships/XmiHasSegment.cs
+++ b/Entities/Relationships/XmiHasSegment.cs
@@ -1,4 +1,5 @@
 using XmiSchema.Entities.Bases;
+using XmiSchema.Entities.Commons;
 
 namespace XmiSchema.Entities.Relationships;
 
@@ -19,7 +20,7 @@ public class XmiHasSegment : XmiBaseRelationship
     public XmiHasSegment(
         string id,
         XmiBaseEntity source,
-        XmiBaseEntity target,
+        XmiSegment target,
         string name,
         string description,
         string entityName
@@ -34,7 +35,7 @@ public class XmiHasSegment : XmiBaseRelationship
     /// <param name="target">Segment entity.</param>
     public XmiHasSegment(
         XmiBaseEntity source,
-        XmiBaseEntity target
+        XmiSegment target
     ) : base(source, target, nameof(XmiHasSegment))
     {
     }

--- a/Entities/Relationships/XmiHasStorey.cs
+++ b/Entities/Relationships/XmiHasStorey.cs
@@ -1,4 +1,5 @@
 using XmiSchema.Entities.Bases;
+using XmiSchema.Entities.Commons;
 
 namespace XmiSchema.Entities.Relationships;
 
@@ -19,7 +20,7 @@ public class XmiHasStorey : XmiBaseRelationship
     public XmiHasStorey(
         string id,
         XmiBaseEntity source,
-        XmiBaseEntity target,
+        XmiStorey target,
         string name,
         string description,
         string entityName
@@ -34,7 +35,7 @@ public class XmiHasStorey : XmiBaseRelationship
     /// <param name="target">Storey entity.</param>
     public XmiHasStorey(
         XmiBaseEntity source,
-        XmiBaseEntity target
+        XmiStorey target
     ) : base(source, target, nameof(XmiHasStorey))
     {
     }

--- a/Entities/Relationships/XmiHasStructuralCurveMember.cs
+++ b/Entities/Relationships/XmiHasStructuralCurveMember.cs
@@ -1,4 +1,5 @@
 using XmiSchema.Entities.Bases;
+using XmiSchema.Entities.StructuralAnalytical;
 
 namespace XmiSchema.Entities.Relationships;
 
@@ -19,7 +20,7 @@ public class XmiHasStructuralCurveMember : XmiBaseRelationship
     public XmiHasStructuralCurveMember(
         string id,
         XmiBasePhysicalEntity source,
-        XmiBaseStructuralAnalyticalEntity target,
+        XmiStructuralCurveMember target,
         string name,
         string description,
         string entityName
@@ -34,7 +35,7 @@ public class XmiHasStructuralCurveMember : XmiBaseRelationship
     /// <param name="target">Structural analytical curve member entity.</param>
     public XmiHasStructuralCurveMember(
         XmiBasePhysicalEntity source,
-        XmiBaseStructuralAnalyticalEntity target
+        XmiStructuralCurveMember target
     ) : base(source, target, nameof(XmiHasStructuralCurveMember))
     {
     }

--- a/Entities/Relationships/XmiHasStructuralPointConnection.cs
+++ b/Entities/Relationships/XmiHasStructuralPointConnection.cs
@@ -1,4 +1,5 @@
 using XmiSchema.Entities.Bases;
+using XmiSchema.Entities.StructuralAnalytical;
 
 namespace XmiSchema.Entities.Relationships;
 
@@ -19,7 +20,7 @@ public class XmiHasStructuralPointConnection : XmiBaseRelationship
     public XmiHasStructuralPointConnection(
         string id,
         XmiBaseStructuralAnalyticalEntity source,
-        XmiBaseStructuralAnalyticalEntity target,
+        XmiStructuralPointConnection target,
         string name,
         string description,
         string entityName
@@ -34,7 +35,7 @@ public class XmiHasStructuralPointConnection : XmiBaseRelationship
     /// <param name="target">Node entity.</param>
     public XmiHasStructuralPointConnection(
         XmiBaseStructuralAnalyticalEntity source,
-        XmiBaseStructuralAnalyticalEntity target
+        XmiStructuralPointConnection target
     ) : base(source, target, nameof(XmiHasStructuralPointConnection))
     {
     }

--- a/Managers/IXmiManager.cs
+++ b/Managers/IXmiManager.cs
@@ -300,7 +300,7 @@ namespace XmiSchema.Managers
         /// <param name="ifcGuid">Optional IFC GUID reference.</param>
         /// <param name="nativeId">Native identifier within the authoring system.</param>
         /// <param name="description">Optional description for the material.</param>
-        /// <param name="materialType">Type classification for the material.</param>
+        /// <param name="materialType">Domain classification for the material.</param>
         /// <param name="grade">Material grade number.</param>
         /// <param name="unitWeight">Density in kN/m^3 or similar units.</param>
         /// <param name="eModulus">Elastic modulus string as defined in source.</param>

--- a/Managers/XmiModel.cs
+++ b/Managers/XmiModel.cs
@@ -357,6 +357,68 @@ namespace XmiSchema.Managers
         }
 
         /// <summary>
+        /// Finds all lines that are coincident with the given line.
+        /// Two lines are coincident if they occupy the same space, regardless of direction.
+        /// </summary>
+        /// <param name="line">The line to match against.</param>
+        /// <returns>All coincident lines (excluding the input line itself if it exists in the model).</returns>
+        public IEnumerable<XmiLine3d> FindCoincidentLines(XmiLine3d line)
+        {
+            if (line == null) return Enumerable.Empty<XmiLine3d>();
+
+            return Entities
+                .OfType<XmiLine3d>()
+                .Where(l => !ReferenceEquals(l, line) && l.IsCoincident(line));
+        }
+
+        /// <summary>
+        /// Finds all lines that are directionally equal to the given line.
+        /// Two lines are directionally equal if they have the same coordinates AND the same direction.
+        /// </summary>
+        /// <param name="line">The line to match against.</param>
+        /// <returns>All directionally equal lines (excluding the input line itself if it exists in the model).</returns>
+        public IEnumerable<XmiLine3d> FindDirectionallyEqualLines(XmiLine3d line)
+        {
+            if (line == null) return Enumerable.Empty<XmiLine3d>();
+
+            return Entities
+                .OfType<XmiLine3d>()
+                .Where(l => !ReferenceEquals(l, line) && l.IsDirectionallyEqual(line));
+        }
+
+        /// <summary>
+        /// Finds all <see cref="XmiHasLine3d"/> relationships whose targets are coincident
+        /// with the given line.
+        /// Use for detecting redundant geometry relationships.
+        /// </summary>
+        /// <param name="line">The line to match against.</param>
+        /// <returns>All relationships with coincident targets.</returns>
+        public IEnumerable<XmiHasLine3d> FindCoincidentLineRelationships(XmiLine3d line)
+        {
+            if (line == null) return Enumerable.Empty<XmiHasLine3d>();
+
+            return Relationships
+                .OfType<XmiHasLine3d>()
+                .Where(rel => rel.TargetLine3d.IsCoincident(line));
+        }
+
+        /// <summary>
+        /// Finds all <see cref="XmiHasLine3d"/> relationships whose targets are directionally
+        /// equal to the given line.
+        /// Use when direction/vector matters.
+        /// </summary>
+        /// <param name="line">The line to match against.</param>
+        /// <returns>All relationships with directionally equal targets.</returns>
+        public IEnumerable<XmiHasLine3d> FindDirectionallyEqualLineRelationships(XmiLine3d line)
+        {
+            if (line == null) return Enumerable.Empty<XmiHasLine3d>();
+
+            return Relationships
+                .OfType<XmiHasLine3d>()
+                .Where(rel => rel.TargetLine3d.IsDirectionallyEqual(line));
+        }
+
+        /// <summary>
         /// Creates a new <see cref="XmiPoint3d"/> entity, adding it to the model.
         /// </summary>
         /// <param name="id">Unique identifier.</param>

--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ XMI entities include an `ifcGuid` property, allowing direct mapping to IFC eleme
 Following industry best practices for AEC data schemas:
 
 1. **Unique Identification**: Every entity has a stable `id`, optional `ifcGuid` for IFC interoperability, and `nativeId` for source system traceability
-2. **Polymorphic Serialization**: `EntityType` discriminator enables type-safe deserialization of heterogeneous entity collections
-3. **Explicit Relationships**: Graph edges (relationships) are first-class citizens with their own identity and metadata
-4. **Unit Awareness**: `XmiUnit` entities define measurement units for proper unit conversion across systems
-5. **Tolerance-Aware Geometry**: Point deduplication with configurable geometric tolerance prevents duplicate coordinates
+2. **Polymorphic Serialization**: `EntityName` discriminator enables type-safe deserialization of heterogeneous entity collections
+3. **Domain Classification**: Entities include a `Domain` field (Physical, StructuralAnalytical, Geometry, Functional, Shared) to make payload routing explicit
+4. **Explicit Relationships**: Graph edges (relationships) are first-class citizens with their own identity and metadata
+5. **Unit Awareness**: `XmiUnit` entities define measurement units for proper unit conversion across systems
+6. **Tolerance-Aware Geometry**: Point deduplication with configurable geometric tolerance prevents duplicate coordinates
 
 ## Installation
 
@@ -199,8 +200,8 @@ XMI serializes to a clean JSON structure:
       "ifcGuid": "3$HnSh4fn5$vQIE9d8M0L9",
       "NativeId": "MAT_C40",
       "Description": "High-strength concrete",
-      "EntityType": "XmiMaterial",
-      "Type": "Material",
+      "EntityName": "XmiMaterial",
+      "Domain": "Shared",
       "MaterialType": "Concrete",
       "Grade": 40,
       "UnitWeight": 24
@@ -209,7 +210,7 @@ XMI serializes to a clean JSON structure:
   "Relationships": [
     {
       "id": "rel-1",
-      "EntityType": "XmiHasMaterial",
+      "EntityName": "XmiHasMaterial",
       "SourceId": "col-1",
       "TargetId": "mat-1"
     }

--- a/XmiSchema.Tests/Entities/Bases/XmiBaseEntityTests.cs
+++ b/XmiSchema.Tests/Entities/Bases/XmiBaseEntityTests.cs
@@ -23,22 +23,22 @@ public class XmiBaseEntityTests
     /// Ensures entity type defaults to the class name whenever omitted.
     /// </summary>
     [Fact]
-    public void Constructor_DefaultsEntityType()
+    public void Constructor_DefaultsEntityName()
     {
         var entity = new XmiBaseEntity("entity-2", "Entity", "ifc", "native", "desc", string.Empty, XmiBaseEntityDomainEnum.Functional);
 
-        Assert.Equal(nameof(XmiBaseEntity), entity.EntityType);
+        Assert.Equal(nameof(XmiBaseEntity), entity.EntityName);
     }
 
     /// <summary>
-    /// Ensures the Type property is correctly assigned from constructor.
+    /// Ensures the Domain property is correctly assigned from constructor.
     /// </summary>
     [Fact]
-    public void Constructor_AssignsTypeProperty()
+    public void Constructor_AssignsDomainProperty()
     {
         var entity = new XmiBaseEntity("entity-3", "Entity", "ifc", "native", "desc", "TestType", XmiBaseEntityDomainEnum.Physical);
 
-        Assert.Equal(XmiBaseEntityDomainEnum.Physical, entity.Type);
+        Assert.Equal(XmiBaseEntityDomainEnum.Physical, entity.Domain);
     }
 
     /// <summary>
@@ -53,6 +53,6 @@ public class XmiBaseEntityTests
     {
         var entity = new XmiBaseEntity("entity-4", "Entity", "ifc", "native", "desc", "TestType", domainType);
 
-        Assert.Equal(domainType, entity.Type);
+        Assert.Equal(domainType, entity.Domain);
     }
 }

--- a/XmiSchema.Tests/Entities/Bases/XmiBaseGeometryTests.cs
+++ b/XmiSchema.Tests/Entities/Bases/XmiBaseGeometryTests.cs
@@ -11,31 +11,31 @@ public class XmiBaseGeometryTests
 {
     private sealed class StubGeometry : XmiBaseGeometry
     {
-        internal StubGeometry(string? entityType = null)
-            : base("geom-1", "Geom", "ifc", "native", "desc", entityType)
+        internal StubGeometry(string? entityName = null)
+            : base("geom-1", "Geom", "ifc", "native", "desc", entityName)
         {
         }
     }
 
     /// <summary>
-    /// Verifies that omitted entity type values fall back to the geometry type name.
+    /// Verifies that omitted entity name values fall back to the geometry type name.
     /// </summary>
     [Fact]
-    public void Constructor_DefaultsEntityType()
+    public void Constructor_DefaultsEntityName()
     {
         var geometry = new StubGeometry();
 
-        Assert.Equal(nameof(XmiBaseGeometry), geometry.EntityType);
+        Assert.Equal(nameof(XmiBaseGeometry), geometry.EntityName);
     }
 
     /// <summary>
-    /// Verifies that explicit entity type strings are honored.
+    /// Verifies that explicit entity name strings are honored.
     /// </summary>
     [Fact]
-    public void Constructor_UsesProvidedEntityType()
+    public void Constructor_UsesProvidedEntityName()
     {
         var geometry = new StubGeometry("CustomType");
 
-        Assert.Equal("CustomType", geometry.EntityType);
+        Assert.Equal("CustomType", geometry.EntityName);
     }
 }

--- a/XmiSchema.Tests/Entities/Bases/XmiBaseRelationshipTests.cs
+++ b/XmiSchema.Tests/Entities/Bases/XmiBaseRelationshipTests.cs
@@ -26,7 +26,7 @@ public class XmiBaseRelationshipTests
 
         Assert.Equal("Unnamed", relationship.Name);
         Assert.Equal(string.Empty, relationship.Description);
-        Assert.Equal(nameof(XmiBaseRelationship), relationship.EntityType);
+        Assert.Equal(nameof(XmiBaseRelationship), relationship.EntityName);
     }
 
     /// <summary>

--- a/XmiSchema.Tests/Entities/Bases/XmiPhysicalEntityTests.cs
+++ b/XmiSchema.Tests/Entities/Bases/XmiPhysicalEntityTests.cs
@@ -12,25 +12,25 @@ namespace XmiSchema.Tests.Entities.Bases;
 public class XmiPhysicalEntityTests
 {
     /// <summary>
-    /// Ensures the Type property is automatically set to Physical.
+    /// Ensures the Domain property is automatically set to Physical.
     /// </summary>
     [Fact]
-    public void Constructor_SetsTypeToPhysical()
+    public void Constructor_SetsDomainToPhysical()
     {
         var entity = new TestPhysicalEntity("phys-1", "Physical Entity", "ifc", "native", "desc");
 
-        Assert.Equal(XmiBaseEntityDomainEnum.Physical, entity.Type);
+        Assert.Equal(XmiBaseEntityDomainEnum.Physical, entity.Domain);
     }
 
     /// <summary>
-    /// Verifies entity type is set correctly.
+    /// Verifies entity name is set correctly.
     /// </summary>
     [Fact]
-    public void Constructor_AssignsEntityType()
+    public void Constructor_AssignsEntityName()
     {
         var entity = new TestPhysicalEntity("phys-2", "Physical Entity", "ifc", "native", "desc");
 
-        Assert.Equal(nameof(TestPhysicalEntity), entity.EntityType);
+        Assert.Equal(nameof(TestPhysicalEntity), entity.EntityName);
     }
 
     /// <summary>

--- a/XmiSchema.Tests/Entities/Bases/XmiStructuralAnalyticalEntityTests.cs
+++ b/XmiSchema.Tests/Entities/Bases/XmiStructuralAnalyticalEntityTests.cs
@@ -12,25 +12,25 @@ namespace XmiSchema.Tests.Entities.Bases;
 public class XmiStructuralAnalyticalEntityTests
 {
     /// <summary>
-    /// Ensures the Type property is automatically set to StructuralAnalytical.
+    /// Ensures the Domain property is automatically set to StructuralAnalytical.
     /// </summary>
     [Fact]
-    public void Constructor_SetsTypeToStructuralAnalytical()
+    public void Constructor_SetsDomainToStructuralAnalytical()
     {
         var entity = new TestStructuralAnalyticalEntity("struct-1", "Structural Entity", "ifc", "native", "desc");
 
-        Assert.Equal(XmiBaseEntityDomainEnum.StructuralAnalytical, entity.Type);
+        Assert.Equal(XmiBaseEntityDomainEnum.StructuralAnalytical, entity.Domain);
     }
 
     /// <summary>
-    /// Verifies entity type is set correctly.
+    /// Verifies entity name is set correctly.
     /// </summary>
     [Fact]
-    public void Constructor_AssignsEntityType()
+    public void Constructor_AssignsEntityName()
     {
         var entity = new TestStructuralAnalyticalEntity("struct-2", "Structural Entity", "ifc", "native", "desc");
 
-        Assert.Equal(nameof(TestStructuralAnalyticalEntity), entity.EntityType);
+        Assert.Equal(nameof(TestStructuralAnalyticalEntity), entity.EntityName);
     }
 
     /// <summary>

--- a/XmiSchema.Tests/Entities/Commons/XmiSegmentTests.cs
+++ b/XmiSchema.Tests/Entities/Commons/XmiSegmentTests.cs
@@ -123,8 +123,8 @@ public class XmiSegmentTests
         Assert.Equal("ifc-guid-123", segment.IfcGuid);
         Assert.Equal("native-123", segment.NativeId);
         Assert.Equal("Test description", segment.Description);
-        Assert.Equal(nameof(XmiSegment), segment.EntityType);
-        Assert.Equal(XmiBaseEntityDomainEnum.Shared, segment.Type);
+        Assert.Equal(nameof(XmiSegment), segment.EntityName);
+        Assert.Equal(XmiBaseEntityDomainEnum.Shared, segment.Domain);
     }
 
     /// <summary>

--- a/XmiSchema.Tests/Entities/Geometries/XmiLine3dTests.cs
+++ b/XmiSchema.Tests/Entities/Geometries/XmiLine3dTests.cs
@@ -1,9 +1,12 @@
+using XmiSchema.Entities.Geometries;
 using XmiSchema.Enums;
 using XmiSchema.Tests.Managers;
+
 namespace XmiSchema.Tests.Entities.Geometries;
 
 /// <summary>
-/// Verifies the <see cref="XmiLine3d"/> geometric endpoints are stored.
+/// Verifies the <see cref="XmiLine3d"/> geometric endpoints are stored
+/// and equality comparisons work correctly.
 /// </summary>
 public class XmiLine3dTests
 {
@@ -19,4 +22,237 @@ public class XmiLine3dTests
         Assert.NotNull(line.EndPoint);
         Assert.Equal("line-start", line.StartPoint.Id);
     }
+
+    #region Equals (Referential Equality)
+
+    /// <summary>
+    /// Equals returns true when both lines share the same XmiPoint3d references.
+    /// </summary>
+    [Fact]
+    public void Equals_SameReferences_ReturnsTrue()
+    {
+        var startPoint = TestModelFactory.CreatePoint("start", 0, 0, 0);
+        var endPoint = TestModelFactory.CreatePoint("end", 10, 10, 10);
+
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc", startPoint, endPoint);
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc", startPoint, endPoint);
+
+        Assert.True(line1.Equals(line2));
+    }
+
+    /// <summary>
+    /// Equals returns false when lines have different XmiPoint3d instances,
+    /// even if coordinates are identical.
+    /// </summary>
+    [Fact]
+    public void Equals_DifferentReferences_SameCoordinates_ReturnsFalse()
+    {
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("start1", 0, 0, 0),
+            TestModelFactory.CreatePoint("end1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("start2", 0, 0, 0),
+            TestModelFactory.CreatePoint("end2", 10, 10, 10));
+
+        Assert.False(line1.Equals(line2));
+    }
+
+    /// <summary>
+    /// Equals returns false when comparing with null.
+    /// </summary>
+    [Fact]
+    public void Equals_Null_ReturnsFalse()
+    {
+        var line = TestModelFactory.CreateLine();
+
+        Assert.False(line.Equals(null));
+    }
+
+    #endregion
+
+    #region IsDirectionallyEqual (Same Direction)
+
+    /// <summary>
+    /// IsDirectionallyEqual returns true when coordinates match and direction is the same.
+    /// </summary>
+    [Fact]
+    public void IsDirectionallyEqual_SameCoordinates_SameDirection_ReturnsTrue()
+    {
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("start1", 0, 0, 0),
+            TestModelFactory.CreatePoint("end1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("start2", 0, 0, 0),
+            TestModelFactory.CreatePoint("end2", 10, 10, 10));
+
+        Assert.True(line1.IsDirectionallyEqual(line2));
+    }
+
+    /// <summary>
+    /// IsDirectionallyEqual returns true when coordinates are within tolerance.
+    /// </summary>
+    [Fact]
+    public void IsDirectionallyEqual_CoordinatesWithinTolerance_ReturnsTrue()
+    {
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("start1", 0, 0, 0),
+            TestModelFactory.CreatePoint("end1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("start2", 0 + 1e-11, 0, 0),
+            TestModelFactory.CreatePoint("end2", 10 + 1e-11, 10, 10));
+
+        Assert.True(line1.IsDirectionallyEqual(line2));
+    }
+
+    /// <summary>
+    /// IsDirectionallyEqual returns false when lines have opposite direction.
+    /// </summary>
+    [Fact]
+    public void IsDirectionallyEqual_OppositeDirection_ReturnsFalse()
+    {
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("start1", 0, 0, 0),
+            TestModelFactory.CreatePoint("end1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("start2", 10, 10, 10),
+            TestModelFactory.CreatePoint("end2", 0, 0, 0));
+
+        Assert.False(line1.IsDirectionallyEqual(line2));
+    }
+
+    /// <summary>
+    /// IsDirectionallyEqual returns false when coordinates differ.
+    /// </summary>
+    [Fact]
+    public void IsDirectionallyEqual_DifferentCoordinates_ReturnsFalse()
+    {
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("start1", 0, 0, 0),
+            TestModelFactory.CreatePoint("end1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("start2", 0, 0, 0),
+            TestModelFactory.CreatePoint("end2", 20, 20, 20));
+
+        Assert.False(line1.IsDirectionallyEqual(line2));
+    }
+
+    /// <summary>
+    /// IsDirectionallyEqual returns false when comparing with null.
+    /// </summary>
+    [Fact]
+    public void IsDirectionallyEqual_Null_ReturnsFalse()
+    {
+        var line = TestModelFactory.CreateLine();
+
+        Assert.False(line.IsDirectionallyEqual(null));
+    }
+
+    #endregion
+
+    #region IsCoincident (Same Segment Regardless of Direction)
+
+    /// <summary>
+    /// IsCoincident returns true when lines have the same direction.
+    /// </summary>
+    [Fact]
+    public void IsCoincident_SameDirection_ReturnsTrue()
+    {
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("start1", 0, 0, 0),
+            TestModelFactory.CreatePoint("end1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("start2", 0, 0, 0),
+            TestModelFactory.CreatePoint("end2", 10, 10, 10));
+
+        Assert.True(line1.IsCoincident(line2));
+    }
+
+    /// <summary>
+    /// IsCoincident returns true when lines have opposite direction (A->B vs B->A).
+    /// </summary>
+    [Fact]
+    public void IsCoincident_OppositeDirection_ReturnsTrue()
+    {
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("start1", 0, 0, 0),
+            TestModelFactory.CreatePoint("end1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("start2", 10, 10, 10),
+            TestModelFactory.CreatePoint("end2", 0, 0, 0));
+
+        Assert.True(line1.IsCoincident(line2));
+    }
+
+    /// <summary>
+    /// IsCoincident returns true when coordinates are within tolerance, opposite direction.
+    /// </summary>
+    [Fact]
+    public void IsCoincident_OppositeDirection_WithinTolerance_ReturnsTrue()
+    {
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("start1", 0, 0, 0),
+            TestModelFactory.CreatePoint("end1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("start2", 10 + 1e-11, 10, 10),
+            TestModelFactory.CreatePoint("end2", 0 + 1e-11, 0, 0));
+
+        Assert.True(line1.IsCoincident(line2));
+    }
+
+    /// <summary>
+    /// IsCoincident returns false when lines occupy different space.
+    /// </summary>
+    [Fact]
+    public void IsCoincident_DifferentCoordinates_ReturnsFalse()
+    {
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("start1", 0, 0, 0),
+            TestModelFactory.CreatePoint("end1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("start2", 5, 5, 5),
+            TestModelFactory.CreatePoint("end2", 15, 15, 15));
+
+        Assert.False(line1.IsCoincident(line2));
+    }
+
+    /// <summary>
+    /// IsCoincident returns false when comparing with null.
+    /// </summary>
+    [Fact]
+    public void IsCoincident_Null_ReturnsFalse()
+    {
+        var line = TestModelFactory.CreateLine();
+
+        Assert.False(line.IsCoincident(null));
+    }
+
+    #endregion
+
+    #region GetHashCode
+
+    /// <summary>
+    /// GetHashCode returns consistent values for lines with same point references.
+    /// </summary>
+    [Fact]
+    public void GetHashCode_SameReferences_SameHashCode()
+    {
+        var startPoint = TestModelFactory.CreatePoint("start", 0, 0, 0);
+        var endPoint = TestModelFactory.CreatePoint("end", 10, 10, 10);
+
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc", startPoint, endPoint);
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc", startPoint, endPoint);
+
+        Assert.Equal(line1.GetHashCode(), line2.GetHashCode());
+    }
+
+    #endregion
 }

--- a/XmiSchema.Tests/Entities/Physical/XmiBeamTests.cs
+++ b/XmiSchema.Tests/Entities/Physical/XmiBeamTests.cs
@@ -20,7 +20,7 @@ public class XmiBeamTests
         Assert.Equal("beam-1", beam.Id);
         Assert.Equal("Beam beam-1", beam.Name);
         Assert.Equal("BEAM-1", beam.NativeId);
-        Assert.Equal(nameof(XmiBeam), beam.EntityType);
+        Assert.Equal(nameof(XmiBeam), beam.EntityName);
         Assert.Equal(XmiSystemLineEnum.MiddleMiddle, beam.SystemLine);
         Assert.Equal(5.0, beam.Length);
     }
@@ -29,11 +29,11 @@ public class XmiBeamTests
     /// Verifies that XmiBeam inherits from XmiBasePhysicalEntity and has Physical type.
     /// </summary>
     [Fact]
-    public void Constructor_SetsTypeToPhysical()
+    public void Constructor_SetsDomainToPhysical()
     {
         var beam = TestModelFactory.CreateBeam();
 
-        Assert.Equal(XmiBaseEntityDomainEnum.Physical, beam.Type);
+        Assert.Equal(XmiBaseEntityDomainEnum.Physical, beam.Domain);
         Assert.IsAssignableFrom<XmiBasePhysicalEntity>(beam);
     }
 

--- a/XmiSchema.Tests/Entities/Physical/XmiColumnTests.cs
+++ b/XmiSchema.Tests/Entities/Physical/XmiColumnTests.cs
@@ -23,7 +23,7 @@ public class XmiColumnTests
         Assert.Equal("col-1", column.Id);
         Assert.Equal("Column col-1", column.Name);
         Assert.Equal("COL-1", column.NativeId);
-        Assert.Equal(nameof(XmiColumn), column.EntityType);
+        Assert.Equal(nameof(XmiColumn), column.EntityName);
         Assert.Equal(XmiSystemLineEnum.MiddleMiddle, column.SystemLine);
         Assert.Equal(3.5, column.Length);
     }
@@ -32,11 +32,11 @@ public class XmiColumnTests
     /// Verifies that XmiColumn inherits from XmiBasePhysicalEntity and has Physical type.
     /// </summary>
     [Fact]
-    public void Constructor_SetsTypeToPhysical()
+    public void Constructor_SetsDomainToPhysical()
     {
         var column = TestModelFactory.CreateColumn();
 
-        Assert.Equal(XmiBaseEntityDomainEnum.Physical, column.Type);
+        Assert.Equal(XmiBaseEntityDomainEnum.Physical, column.Domain);
         Assert.IsAssignableFrom<XmiBasePhysicalEntity>(column);
     }
 

--- a/XmiSchema.Tests/Entities/Physical/XmiSlabTests.cs
+++ b/XmiSchema.Tests/Entities/Physical/XmiSlabTests.cs
@@ -24,7 +24,7 @@ public class XmiSlabTests
         Assert.Equal("ifc-slab", slab.IfcGuid);
         Assert.Equal("native-slab-1", slab.NativeId);
         Assert.Equal("Concrete slab", slab.Description);
-        Assert.Equal(nameof(XmiSlab), slab.EntityType);
+        Assert.Equal(nameof(XmiSlab), slab.EntityName);
         Assert.Equal(1.2, slab.ZOffset);
         Assert.Equal(new XmiAxis(1, 0, 0), slab.LocalAxisX);
         Assert.Equal(new XmiAxis(0, 1, 0), slab.LocalAxisY);
@@ -36,11 +36,11 @@ public class XmiSlabTests
     /// Verifies that XmiSlab inherits from XmiBasePhysicalEntity and has Physical type.
     /// </summary>
     [Fact]
-    public void Constructor_SetsTypeToPhysical()
+    public void Constructor_SetsDomainToPhysical()
     {
         var slab = new XmiSlab("slab-2", "S2", "ifc", "native", "desc", 0, new XmiAxis(1, 0, 0), new XmiAxis(0, 1, 0), new XmiAxis(0, 0, 1), 0.3);
 
-        Assert.Equal(XmiBaseEntityDomainEnum.Physical, slab.Type);
+        Assert.Equal(XmiBaseEntityDomainEnum.Physical, slab.Domain);
         Assert.IsAssignableFrom<XmiBasePhysicalEntity>(slab);
     }
 

--- a/XmiSchema.Tests/Entities/Physical/XmiWallTests.cs
+++ b/XmiSchema.Tests/Entities/Physical/XmiWallTests.cs
@@ -24,7 +24,7 @@ public class XmiWallTests
         Assert.Equal("ifc-wall", wall.IfcGuid);
         Assert.Equal("native-wall-1", wall.NativeId);
         Assert.Equal("Concrete wall", wall.Description);
-        Assert.Equal(nameof(XmiWall), wall.EntityType);
+        Assert.Equal(nameof(XmiWall), wall.EntityName);
         Assert.Equal(0.4, wall.ZOffset);
         Assert.Equal(new XmiAxis(1, 0, 0), wall.LocalAxisX);
         Assert.Equal(new XmiAxis(0, 1, 0), wall.LocalAxisY);
@@ -36,11 +36,11 @@ public class XmiWallTests
     /// Verifies that XmiWall inherits from XmiBasePhysicalEntity and has Physical type.
     /// </summary>
     [Fact]
-    public void Constructor_SetsTypeToPhysical()
+    public void Constructor_SetsDomainToPhysical()
     {
         var wall = new XmiWall("wall-2", "W2", "ifc", "native", "desc", 0, new XmiAxis(1, 0, 0), new XmiAxis(0, 1, 0), new XmiAxis(0, 0, 1), 3.0);
 
-        Assert.Equal(XmiBaseEntityDomainEnum.Physical, wall.Type);
+        Assert.Equal(XmiBaseEntityDomainEnum.Physical, wall.Domain);
         Assert.IsAssignableFrom<XmiBasePhysicalEntity>(wall);
     }
 

--- a/XmiSchema.Tests/Entities/Relationships/XmiHasCrossSectionTests.cs
+++ b/XmiSchema.Tests/Entities/Relationships/XmiHasCrossSectionTests.cs
@@ -1,6 +1,7 @@
 using XmiSchema.Enums;
 using XmiSchema.Entities.Relationships;
 using XmiSchema.Tests.Managers;
+
 namespace XmiSchema.Tests.Entities.Relationships;
 
 /// <summary>
@@ -20,7 +21,7 @@ public class XmiHasCrossSectionTests
             nameof(XmiHasCrossSection));
 
         Assert.Equal("rel-sec", relation.Id);
-        Assert.Equal(nameof(XmiHasCrossSection), relation.EntityType);
+        Assert.Equal(nameof(XmiHasCrossSection), relation.EntityName);
     }
 
     [Fact]

--- a/XmiSchema.Tests/Entities/Relationships/XmiHasGeometryTests.cs
+++ b/XmiSchema.Tests/Entities/Relationships/XmiHasGeometryTests.cs
@@ -20,7 +20,7 @@ public class XmiHasGeometryTests
             nameof(XmiHasGeometry));
 
         Assert.Equal("rel-geom", relation.Id);
-        Assert.Equal(nameof(XmiHasGeometry), relation.EntityType);
+        Assert.Equal(nameof(XmiHasGeometry), relation.EntityName);
     }
 
     [Fact]

--- a/XmiSchema.Tests/Entities/Relationships/XmiHasLine3DTests.cs
+++ b/XmiSchema.Tests/Entities/Relationships/XmiHasLine3DTests.cs
@@ -1,20 +1,23 @@
-using XmiSchema.Enums;
+using XmiSchema.Entities.Geometries;
 using XmiSchema.Entities.Relationships;
+using XmiSchema.Enums;
 using XmiSchema.Tests.Managers;
+
 namespace XmiSchema.Tests.Entities.Relationships;
 
 /// <summary>
-/// Ensures line relationships retain their metadata.
+/// Ensures line relationships retain their metadata and target equality methods work correctly.
 /// </summary>
 public class XmiHasLine3DTests
 {
     [Fact]
     public void Constructor_AssignsMetadata()
     {
+        var line = TestModelFactory.CreateLine();
         var relation = new XmiHasLine3d(
             "rel-line",
             TestModelFactory.CreateCurveMember(),
-            TestModelFactory.CreateCurveMember("curve-b"),
+            line,
             "AlignedWith",
             "desc",
             nameof(XmiHasLine3d));
@@ -26,8 +29,176 @@ public class XmiHasLine3DTests
     [Fact]
     public void Constructor_GeneratesIdentifier()
     {
-        var relation = new XmiHasLine3d(TestModelFactory.CreateCurveMember(), TestModelFactory.CreateCurveMember("curve-b"));
+        var line = TestModelFactory.CreateLine();
+        var relation = new XmiHasLine3d(TestModelFactory.CreateCurveMember(), line);
 
         Assert.False(string.IsNullOrWhiteSpace(relation.Id));
     }
+
+    #region TargetLine3d Property
+
+    [Fact]
+    public void TargetLine3d_ReturnsStronglyTypedTarget()
+    {
+        var line = TestModelFactory.CreateLine();
+        var relation = new XmiHasLine3d(TestModelFactory.CreateCurveMember(), line);
+
+        Assert.Same(line, relation.TargetLine3d);
+    }
+
+    #endregion
+
+    #region HasSameTarget (Referential Equality)
+
+    [Fact]
+    public void HasSameTarget_SameLineReference_ReturnsTrue()
+    {
+        var startPoint = TestModelFactory.CreatePoint("start", 0, 0, 0);
+        var endPoint = TestModelFactory.CreatePoint("end", 10, 10, 10);
+        var line = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc", startPoint, endPoint);
+
+        var rel1 = new XmiHasLine3d(TestModelFactory.CreateCurveMember("c1"), line);
+        var rel2 = new XmiHasLine3d(TestModelFactory.CreateCurveMember("c2"), line);
+
+        Assert.True(rel1.HasSameTarget(rel2));
+    }
+
+    [Fact]
+    public void HasSameTarget_DifferentLineReferences_SameCoords_ReturnsFalse()
+    {
+        var startPoint = TestModelFactory.CreatePoint("start", 0, 0, 0);
+        var endPoint = TestModelFactory.CreatePoint("end", 10, 10, 10);
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc", startPoint, endPoint);
+
+        var startPoint2 = TestModelFactory.CreatePoint("start2", 0, 0, 0);
+        var endPoint2 = TestModelFactory.CreatePoint("end2", 10, 10, 10);
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc", startPoint2, endPoint2);
+
+        var rel1 = new XmiHasLine3d(TestModelFactory.CreateCurveMember("c1"), line1);
+        var rel2 = new XmiHasLine3d(TestModelFactory.CreateCurveMember("c2"), line2);
+
+        Assert.False(rel1.HasSameTarget(rel2));
+    }
+
+    [Fact]
+    public void HasSameTarget_Null_ReturnsFalse()
+    {
+        var line = TestModelFactory.CreateLine();
+        var rel = new XmiHasLine3d(TestModelFactory.CreateCurveMember(), line);
+
+        Assert.False(rel.HasSameTarget(null));
+    }
+
+    #endregion
+
+    #region HasDirectionallyEqualTarget (Same Direction)
+
+    [Fact]
+    public void HasDirectionallyEqualTarget_SameCoordsSameDirection_ReturnsTrue()
+    {
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("s1", 0, 0, 0),
+            TestModelFactory.CreatePoint("e1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("s2", 0, 0, 0),
+            TestModelFactory.CreatePoint("e2", 10, 10, 10));
+
+        var rel1 = new XmiHasLine3d(TestModelFactory.CreateCurveMember("c1"), line1);
+        var rel2 = new XmiHasLine3d(TestModelFactory.CreateCurveMember("c2"), line2);
+
+        Assert.True(rel1.HasDirectionallyEqualTarget(rel2));
+    }
+
+    [Fact]
+    public void HasDirectionallyEqualTarget_OppositeDirection_ReturnsFalse()
+    {
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("s1", 0, 0, 0),
+            TestModelFactory.CreatePoint("e1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("s2", 10, 10, 10),
+            TestModelFactory.CreatePoint("e2", 0, 0, 0));
+
+        var rel1 = new XmiHasLine3d(TestModelFactory.CreateCurveMember("c1"), line1);
+        var rel2 = new XmiHasLine3d(TestModelFactory.CreateCurveMember("c2"), line2);
+
+        Assert.False(rel1.HasDirectionallyEqualTarget(rel2));
+    }
+
+    [Fact]
+    public void HasDirectionallyEqualTarget_Null_ReturnsFalse()
+    {
+        var line = TestModelFactory.CreateLine();
+        var rel = new XmiHasLine3d(TestModelFactory.CreateCurveMember(), line);
+
+        Assert.False(rel.HasDirectionallyEqualTarget(null));
+    }
+
+    #endregion
+
+    #region HasCoincidentTarget (Same Space)
+
+    [Fact]
+    public void HasCoincidentTarget_SameDirection_ReturnsTrue()
+    {
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("s1", 0, 0, 0),
+            TestModelFactory.CreatePoint("e1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("s2", 0, 0, 0),
+            TestModelFactory.CreatePoint("e2", 10, 10, 10));
+
+        var rel1 = new XmiHasLine3d(TestModelFactory.CreateCurveMember("c1"), line1);
+        var rel2 = new XmiHasLine3d(TestModelFactory.CreateCurveMember("c2"), line2);
+
+        Assert.True(rel1.HasCoincidentTarget(rel2));
+    }
+
+    [Fact]
+    public void HasCoincidentTarget_OppositeDirection_ReturnsTrue()
+    {
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("s1", 0, 0, 0),
+            TestModelFactory.CreatePoint("e1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("s2", 10, 10, 10),
+            TestModelFactory.CreatePoint("e2", 0, 0, 0));
+
+        var rel1 = new XmiHasLine3d(TestModelFactory.CreateCurveMember("c1"), line1);
+        var rel2 = new XmiHasLine3d(TestModelFactory.CreateCurveMember("c2"), line2);
+
+        Assert.True(rel1.HasCoincidentTarget(rel2));
+    }
+
+    [Fact]
+    public void HasCoincidentTarget_DifferentCoords_ReturnsFalse()
+    {
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("s1", 0, 0, 0),
+            TestModelFactory.CreatePoint("e1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("s2", 5, 5, 5),
+            TestModelFactory.CreatePoint("e2", 15, 15, 15));
+
+        var rel1 = new XmiHasLine3d(TestModelFactory.CreateCurveMember("c1"), line1);
+        var rel2 = new XmiHasLine3d(TestModelFactory.CreateCurveMember("c2"), line2);
+
+        Assert.False(rel1.HasCoincidentTarget(rel2));
+    }
+
+    [Fact]
+    public void HasCoincidentTarget_Null_ReturnsFalse()
+    {
+        var line = TestModelFactory.CreateLine();
+        var rel = new XmiHasLine3d(TestModelFactory.CreateCurveMember(), line);
+
+        Assert.False(rel.HasCoincidentTarget(null));
+    }
+
+    #endregion
 }

--- a/XmiSchema.Tests/Entities/Relationships/XmiHasMaterialTests.cs
+++ b/XmiSchema.Tests/Entities/Relationships/XmiHasMaterialTests.cs
@@ -21,7 +21,7 @@ public class XmiHasMaterialTests
 
         Assert.Equal("rel-mat", relation.Id);
         Assert.Equal("Uses", relation.Name);
-        Assert.Equal(nameof(XmiHasMaterial), relation.EntityType);
+        Assert.Equal(nameof(XmiHasMaterial), relation.EntityName);
     }
 
     [Fact]

--- a/XmiSchema.Tests/Entities/Relationships/XmiHasPoint3DTests.cs
+++ b/XmiSchema.Tests/Entities/Relationships/XmiHasPoint3DTests.cs
@@ -29,7 +29,7 @@ public class XmiHasPoint3DTests
 
         Assert.Equal("rel-1", relation.Id);
         Assert.Equal("Owns", relation.Name);
-        Assert.Equal(nameof(XmiHasPoint3d), relation.EntityType);
+        Assert.Equal(nameof(XmiHasPoint3d), relation.EntityName);
     }
 
     /// <summary>

--- a/XmiSchema.Tests/Entities/Relationships/XmiHasPoint3DTests.cs
+++ b/XmiSchema.Tests/Entities/Relationships/XmiHasPoint3DTests.cs
@@ -22,7 +22,7 @@ public class XmiHasPoint3DTests
         var relation = new XmiHasPoint3d(
             "rel-1",
             TestModelFactory.CreateCurveMember(),
-            TestModelFactory.CreatePointConnection(),
+            TestModelFactory.CreatePoint(),
             "Owns",
             "desc",
             nameof(XmiHasPoint3d));
@@ -38,7 +38,7 @@ public class XmiHasPoint3DTests
     [Fact]
     public void Constructor_WithAutoIdentifier_GeneratesId()
     {
-        var relation = new XmiHasPoint3d(TestModelFactory.CreateCurveMember(), TestModelFactory.CreatePointConnection());
+        var relation = new XmiHasPoint3d(TestModelFactory.CreateCurveMember(), TestModelFactory.CreatePoint());
 
         Assert.False(string.IsNullOrWhiteSpace(relation.Id));
         Assert.Equal(nameof(XmiHasPoint3d), relation.Name);

--- a/XmiSchema.Tests/Entities/Relationships/XmiHasStructuralCurveMemberTests.cs
+++ b/XmiSchema.Tests/Entities/Relationships/XmiHasStructuralCurveMemberTests.cs
@@ -35,7 +35,7 @@ public class XmiHasStructuralCurveMemberTests
         Assert.Equal("PhysicalToAnalytical", relation.Name);
         Assert.Equal(beam, relation.Source);
         Assert.Equal(curveMember, relation.Target);
-        Assert.Equal(nameof(XmiHasStructuralCurveMember), relation.EntityType);
+        Assert.Equal(nameof(XmiHasStructuralCurveMember), relation.EntityName);
     }
 
     /// <summary>

--- a/XmiSchema.Tests/Managers/XmiModelTests.cs
+++ b/XmiSchema.Tests/Managers/XmiModelTests.cs
@@ -1200,5 +1200,231 @@ public class XmiModelTests
             0.5f,
             arc));
     }
+
+    #region FindCoincidentLines
+
+    /// <summary>
+    /// FindCoincidentLines returns lines that occupy the same space.
+    /// </summary>
+    [Fact]
+    public void FindCoincidentLines_ReturnsCoincidentLines()
+    {
+        var model = new XmiModel();
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("s1", 0, 0, 0),
+            TestModelFactory.CreatePoint("e1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("s2", 0, 0, 0),
+            TestModelFactory.CreatePoint("e2", 10, 10, 10));
+
+        var line3 = new XmiLine3d("line-3", "Line 3", "ifc-3", "N3", "desc",
+            TestModelFactory.CreatePoint("s3", 5, 5, 5),
+            TestModelFactory.CreatePoint("e3", 15, 15, 15));
+
+        model.AddXmiLine3d(line1);
+        model.AddXmiLine3d(line2);
+        model.AddXmiLine3d(line3);
+
+        var coincident = model.FindCoincidentLines(line1).ToList();
+
+        Assert.Single(coincident);
+        Assert.Contains(line2, coincident);
+        Assert.DoesNotContain(line3, coincident);
+    }
+
+    /// <summary>
+    /// FindCoincidentLines includes opposite direction lines.
+    /// </summary>
+    [Fact]
+    public void FindCoincidentLines_IncludesOppositeDirectionLines()
+    {
+        var model = new XmiModel();
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("s1", 0, 0, 0),
+            TestModelFactory.CreatePoint("e1", 10, 10, 10));
+
+        var lineReversed = new XmiLine3d("line-rev", "Line Reversed", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("s2", 10, 10, 10),
+            TestModelFactory.CreatePoint("e2", 0, 0, 0));
+
+        model.AddXmiLine3d(line1);
+        model.AddXmiLine3d(lineReversed);
+
+        var coincident = model.FindCoincidentLines(line1).ToList();
+
+        Assert.Single(coincident);
+        Assert.Contains(lineReversed, coincident);
+    }
+
+    /// <summary>
+    /// FindCoincidentLines returns empty when no matches.
+    /// </summary>
+    [Fact]
+    public void FindCoincidentLines_ReturnsEmptyWhenNoMatches()
+    {
+        var model = new XmiModel();
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("s1", 0, 0, 0),
+            TestModelFactory.CreatePoint("e1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("s2", 100, 100, 100),
+            TestModelFactory.CreatePoint("e2", 200, 200, 200));
+
+        model.AddXmiLine3d(line1);
+        model.AddXmiLine3d(line2);
+
+        var coincident = model.FindCoincidentLines(line1).ToList();
+
+        Assert.Empty(coincident);
+    }
+
+    /// <summary>
+    /// FindCoincidentLines returns empty for null input.
+    /// </summary>
+    [Fact]
+    public void FindCoincidentLines_ReturnsEmptyForNull()
+    {
+        var model = new XmiModel();
+
+        var coincident = model.FindCoincidentLines(null!).ToList();
+
+        Assert.Empty(coincident);
+    }
+
+    #endregion
+
+    #region FindDirectionallyEqualLines
+
+    /// <summary>
+    /// FindDirectionallyEqualLines returns lines with same direction only.
+    /// </summary>
+    [Fact]
+    public void FindDirectionallyEqualLines_ReturnsSameDirectionOnly()
+    {
+        var model = new XmiModel();
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("s1", 0, 0, 0),
+            TestModelFactory.CreatePoint("e1", 10, 10, 10));
+
+        var lineSameDir = new XmiLine3d("line-same", "Line Same", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("s2", 0, 0, 0),
+            TestModelFactory.CreatePoint("e2", 10, 10, 10));
+
+        var lineReversed = new XmiLine3d("line-rev", "Line Reversed", "ifc-3", "N3", "desc",
+            TestModelFactory.CreatePoint("s3", 10, 10, 10),
+            TestModelFactory.CreatePoint("e3", 0, 0, 0));
+
+        model.AddXmiLine3d(line1);
+        model.AddXmiLine3d(lineSameDir);
+        model.AddXmiLine3d(lineReversed);
+
+        var directionallyEqual = model.FindDirectionallyEqualLines(line1).ToList();
+
+        Assert.Single(directionallyEqual);
+        Assert.Contains(lineSameDir, directionallyEqual);
+        Assert.DoesNotContain(lineReversed, directionallyEqual);
+    }
+
+    #endregion
+
+    #region FindCoincidentLineRelationships
+
+    /// <summary>
+    /// FindCoincidentLineRelationships returns relationships with coincident targets.
+    /// </summary>
+    [Fact]
+    public void FindCoincidentLineRelationships_ReturnsRelationshipsWithCoincidentTargets()
+    {
+        var model = new XmiModel();
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("s1", 0, 0, 0),
+            TestModelFactory.CreatePoint("e1", 10, 10, 10));
+
+        var line2 = new XmiLine3d("line-2", "Line 2", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("s2", 0, 0, 0),
+            TestModelFactory.CreatePoint("e2", 10, 10, 10));
+
+        var line3 = new XmiLine3d("line-3", "Line 3", "ifc-3", "N3", "desc",
+            TestModelFactory.CreatePoint("s3", 100, 100, 100),
+            TestModelFactory.CreatePoint("e3", 200, 200, 200));
+
+        var segment1 = TestModelFactory.CreateSegment("seg-1");
+        var segment2 = TestModelFactory.CreateSegment("seg-2");
+        var segment3 = TestModelFactory.CreateSegment("seg-3");
+
+        model.AddXmiLine3d(line1);
+        model.AddXmiLine3d(line2);
+        model.AddXmiLine3d(line3);
+        model.AddXmiSegment(segment1);
+        model.AddXmiSegment(segment2);
+        model.AddXmiSegment(segment3);
+
+        var rel1 = new XmiHasLine3d(segment1, line1);
+        var rel2 = new XmiHasLine3d(segment2, line2);
+        var rel3 = new XmiHasLine3d(segment3, line3);
+        model.AddXmiHasLine3d(rel1);
+        model.AddXmiHasLine3d(rel2);
+        model.AddXmiHasLine3d(rel3);
+
+        var coincidentRels = model.FindCoincidentLineRelationships(line1).ToList();
+
+        Assert.Equal(2, coincidentRels.Count);
+        Assert.Contains(rel1, coincidentRels);
+        Assert.Contains(rel2, coincidentRels);
+        Assert.DoesNotContain(rel3, coincidentRels);
+    }
+
+    #endregion
+
+    #region FindDirectionallyEqualLineRelationships
+
+    /// <summary>
+    /// FindDirectionallyEqualLineRelationships returns relationships with same direction targets.
+    /// </summary>
+    [Fact]
+    public void FindDirectionallyEqualLineRelationships_ReturnsSameDirectionTargets()
+    {
+        var model = new XmiModel();
+        var line1 = new XmiLine3d("line-1", "Line 1", "ifc-1", "N1", "desc",
+            TestModelFactory.CreatePoint("s1", 0, 0, 0),
+            TestModelFactory.CreatePoint("e1", 10, 10, 10));
+
+        var lineSameDir = new XmiLine3d("line-same", "Line Same", "ifc-2", "N2", "desc",
+            TestModelFactory.CreatePoint("s2", 0, 0, 0),
+            TestModelFactory.CreatePoint("e2", 10, 10, 10));
+
+        var lineReversed = new XmiLine3d("line-rev", "Line Reversed", "ifc-3", "N3", "desc",
+            TestModelFactory.CreatePoint("s3", 10, 10, 10),
+            TestModelFactory.CreatePoint("e3", 0, 0, 0));
+
+        var segment1 = TestModelFactory.CreateSegment("seg-1");
+        var segment2 = TestModelFactory.CreateSegment("seg-2");
+        var segment3 = TestModelFactory.CreateSegment("seg-3");
+
+        model.AddXmiLine3d(line1);
+        model.AddXmiLine3d(lineSameDir);
+        model.AddXmiLine3d(lineReversed);
+        model.AddXmiSegment(segment1);
+        model.AddXmiSegment(segment2);
+        model.AddXmiSegment(segment3);
+
+        var rel1 = new XmiHasLine3d(segment1, line1);
+        var rel2 = new XmiHasLine3d(segment2, lineSameDir);
+        var rel3 = new XmiHasLine3d(segment3, lineReversed);
+        model.AddXmiHasLine3d(rel1);
+        model.AddXmiHasLine3d(rel2);
+        model.AddXmiHasLine3d(rel3);
+
+        var directionalRels = model.FindDirectionallyEqualLineRelationships(line1).ToList();
+
+        Assert.Equal(2, directionalRels.Count);
+        Assert.Contains(rel1, directionalRels);
+        Assert.Contains(rel2, directionalRels);
+        Assert.DoesNotContain(rel3, directionalRels);
+    }
+
+    #endregion
 }
 

--- a/XmiSchema.Tests/Managers/XmiSerializationTests.cs
+++ b/XmiSchema.Tests/Managers/XmiSerializationTests.cs
@@ -241,7 +241,7 @@ public class XmiSerializationTests
         var point = TestModelFactory.CreatePoint();
         var json = JsonConvert.SerializeObject(point, _settings);
 
-        Assert.Contains("\"Type\"", json);
+        Assert.Contains("\"Domain\"", json);
         Assert.Contains("\"Geometry\"", json); // XmiPoint3d has Geometry type
     }
 
@@ -272,8 +272,8 @@ public class XmiSerializationTests
             ""ifcGuid"": """",
             ""NativeId"": ""native"",
             ""Description"": """",
-            ""EntityType"": ""XmiMaterial"",
-            ""Type"": ""Shared"",
+            ""EntityName"": ""XmiMaterial"",
+            ""Domain"": ""Shared"",
             ""MaterialType"": ""Steel"",
             ""Grade"": 50,
             ""UnitWeight"": 78.5,
@@ -286,7 +286,7 @@ public class XmiSerializationTests
         var material = JsonConvert.DeserializeObject<XmiMaterial>(json, _settings);
 
         Assert.Equal(XmiMaterialTypeEnum.Steel, material!.MaterialType);
-        Assert.Equal(XmiBaseEntityDomainEnum.Shared, material.Type);
+        Assert.Equal(XmiBaseEntityDomainEnum.Shared, material.Domain);
     }
 
     #endregion
@@ -614,7 +614,7 @@ public class XmiSerializationTests
     }
 
     [Fact]
-    public void PhysicalElements_SerializeWithCorrectType()
+    public void PhysicalElements_SerializeWithCorrectEntityNames()
     {
         var beam = TestModelFactory.CreateBeam();
         var column = TestModelFactory.CreateColumn();
@@ -633,7 +633,7 @@ public class XmiSerializationTests
     }
 
     [Fact]
-    public void MixedEntityTypes_InModel_SerializeCorrectly()
+    public void MixedEntityNames_InModel_SerializeCorrectly()
     {
         var model = new XmiModel();
 


### PR DESCRIPTION
## Summary

- Add `IEquatable<XmiLine3d>` implementation with three distinct equality modes
- Add helper methods to `XmiHasLine3d` for target comparison
- Add line-finding methods to `XmiModel` for geometry queries
- Fix pre-existing test bugs in `XmiHasPoint3DTests`

## Changes

### XmiLine3d Equality Methods

| Method | Comparison Type | Use Case |
|--------|----------------|----------|
| `Equals()` | Referential | Same `XmiPoint3d` object instances |
| `IsDirectionallyEqual()` | Directional/Vector | Same coordinates + same direction (A→B) |
| `IsCoincident()` | Geometric/Spatial | Same space, direction ignored (A→B = B→A) |

### XmiHasLine3d Target Comparison

| Method | Description |
|--------|-------------|
| `TargetLine3d` | Strongly-typed accessor for target |
| `HasSameTarget()` | Referential comparison of targets |
| `HasDirectionallyEqualTarget()` | Directional comparison of targets |
| `HasCoincidentTarget()` | Coincident comparison of targets |

### XmiModel Query Methods

| Method | Description |
|--------|-------------|
| `FindCoincidentLines()` | Find lines occupying same space |
| `FindDirectionallyEqualLines()` | Find lines with same direction |
| `FindCoincidentLineRelationships()` | Find relationships with coincident targets |
| `FindDirectionallyEqualLineRelationships()` | Find relationships with same direction targets |

## Comparison Matrix

| Scenario | `Equals()` | `IsDirectionallyEqual()` | `IsCoincident()` |
|----------|------------|--------------------------|------------------|
| Same references, same direction | ✅ | ✅ | ✅ |
| Different refs, same coords, same direction | ❌ | ✅ | ✅ |
| Different refs, same coords, opposite direction | ❌ | ❌ | ✅ |
| Different coordinates | ❌ | ❌ | ❌ |

## Test Plan

- [x] XmiLine3d equality tests (14 new tests)
- [x] XmiHasLine3d target equality tests (13 new tests)
- [x] XmiModel line-finding tests (8 new tests)
- [x] All 322 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)